### PR TITLE
User registration

### DIFF
--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,4 +1,5 @@
 class LandingController < ApplicationController
   def index
+    @users = User.all
   end
 end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,5 +1,6 @@
 class LandingController < ApplicationController
   def index
+    @disable_nav = true
     @users = User.all
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,12 +7,13 @@ class UsersController < ApplicationController
   end
 
   def create
-    user = User.create!(user_params)
+    user = User.new(user_params)
 
     if user.save
-      redirect_to root_path
+      redirect_to "/users/#{user.id}"
     else
-      redirect_to "/users/new"
+      redirect_to "/register"
+      flash[:alert] = "That email has already been registered. Please enter a new email."
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,10 +3,10 @@ class UsersController < ApplicationController
   end
 
   def show
+    @user = User.find(params[:id])
   end
 
   def create
-    # binding.pry
     user = User.create!(user_params)
 
     if user.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,5 +6,19 @@ class UsersController < ApplicationController
   end
 
   def create
+    # binding.pry
+    user = User.create!(user_params)
+
+    if user.save
+      redirect_to root_path
+    else
+      redirect_to "/users/new"
+    end
+  end
+
+  private
+
+  def user_params
+    params.permit(:name, :email)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   has_many :parties, through: :party_users
 
   validates_presence_of :name, :email
+  validates :email, uniqueness: true
 end

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -1,2 +1,16 @@
 <h1>Landing#index</h1>
 <p>Find me in app/views/landing/index.html.erb</p>
+<h1>Viewing Party Lite</h1>
+
+<div class="users">
+  <% if !@users.empty? %>
+    <h2>Users:</h2>
+    <ul>
+      <% @users.each do |u| %>
+        <li><%= u.name %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>
+
+<h3><%= link_to "Create New User", "/users/new", method: :get, local: true %></h3>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -7,7 +7,7 @@
     <h2>Users:</h2>
     <ul>
       <% @users.each do |u| %>
-        <li><%= u.name %></li>
+        <li><%= link_to u.name, "/users/#{u.id}", method: :get %></li>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/landing/index.html.erb
+++ b/app/views/landing/index.html.erb
@@ -13,4 +13,4 @@
   <% end %>
 </div>
 
-<h3><%= link_to "Create New User", "/users/new", method: :get, local: true %></h3>
+<h3><%= link_to "Create New User", "/register", method: :get, local: true %></h3>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "Home", root_path, method: :get %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,13 @@
   </head>
 
   <body>
+    <%= render "layouts/header" unless @disable_nav %>
+
+    <% flash.each do |type, msg| %>
+      <div>
+        <strong><%= msg %></strong>
+      </div>
+    <% end %>
     <%= yield %>
   </body>
 </html>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,3 @@
-<%= render "layouts/header" %>
 <h1>Users#new</h1>
 <p>Find me in app/views/users/new.html.erb</p>
 
@@ -8,5 +7,5 @@
   <%= f.label :email %>
   <%= f.text_field :email %>
 
-  <%= f.submit "Create New User" %>
+  <%= f.submit "Register" %>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,2 +1,11 @@
 <h1>Users#new</h1>
 <p>Find me in app/views/users/new.html.erb</p>
+
+<%= form_with url: "/users/create", method: :post do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :email %>
+  <%= f.text_field :email %>
+
+  <%= f.submit "Create New User" %>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<%= render "layouts/header" %>
 <h1>Users#new</h1>
 <p>Find me in app/views/users/new.html.erb</p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,2 +1,3 @@
 <h1>Users#show</h1>
 <p>Find me in app/views/users/show.html.erb</p>
+<h1><%= @user.name %>'s Dashboard</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   get "/users/new", to: "users#new"
   get "/users/:id", to: "users#show"
   post "/users/create", to: "users#create"
+
+  get "/register", to: "users#new"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,7 @@
 Rails.application.routes.draw do
   root to: 'landing#index'
+
+  get "/users/new", to: "users#new"
+  post "/users/create", to: "users#create"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   root to: 'landing#index'
 
-  get "/users/:id", to: "users#show"
   get "/users/new", to: "users#new"
+  get "/users/:id", to: "users#show"
   post "/users/create", to: "users#create"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   root to: 'landing#index'
 
+  get "/users/:id", to: "users#show"
   get "/users/new", to: "users#new"
   post "/users/create", to: "users#create"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/spec/features/landing/index_spec.rb
+++ b/spec/features/landing/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'landing page' do
+RSpec.describe 'landing page' do
 
   describe 'display' do
     it 'shows the title of the application' do
@@ -11,7 +11,8 @@ describe 'landing page' do
     it 'shows a button to create a new user' do
       visit root_path
       click_link 'Create New User'
-      expect(current_path).to eq new_user_path
+      
+      expect(current_path).to eq "/users/new"
     end
 
     it 'shows existing user list that is linked to respective user dashboard' do

--- a/spec/features/landing/index_spec.rb
+++ b/spec/features/landing/index_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'landing page' do
       visit root_path
       click_link 'Create New User'
 
-      expect(current_path).to eq "/users/new"
+      expect(current_path).to eq "/register"
     end
 
     it 'shows existing user list that is linked to respective user dashboard' do
@@ -27,7 +27,7 @@ RSpec.describe 'landing page' do
     end
 
     it 'shows a header link redirecting to landing page' do
-      visit "/users/new"
+      visit "/register"
 
       click_link "Home"
       expect(current_path).to eq(root_path)

--- a/spec/features/landing/index_spec.rb
+++ b/spec/features/landing/index_spec.rb
@@ -11,15 +11,19 @@ RSpec.describe 'landing page' do
     it 'shows a button to create a new user' do
       visit root_path
       click_link 'Create New User'
-      
+
       expect(current_path).to eq "/users/new"
     end
 
     it 'shows existing user list that is linked to respective user dashboard' do
       user = User.create(name: 'Michael', email: 'michael@example.net')
       visit root_path
-      click_on "#{user.email}"
-      expect(current_path).to eq(user_path(user.id))
+
+      within(".users") do
+        click_link "#{user.name}"
+      end
+      
+      expect(current_path).to eq("/users/#{user.id}")
     end
 
     it 'shows a header link redirecting to landing page' do

--- a/spec/features/landing/index_spec.rb
+++ b/spec/features/landing/index_spec.rb
@@ -22,14 +22,15 @@ RSpec.describe 'landing page' do
       within(".users") do
         click_link "#{user.name}"
       end
-      
+
       expect(current_path).to eq("/users/#{user.id}")
     end
 
     it 'shows a header link redirecting to landing page' do
-      visit new_user_path
-      click_on 'Home'
-      expect(current_path).to eq('/')
+      visit "/users/new"
+
+      click_link "Home"
+      expect(current_path).to eq(root_path)
     end
 
   end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "users#new" do
+  it "creates a new user" do
+    visit root_path
+
+    within(".users") do
+      expect(page).to_not have_content("Fake Joe")
+    end
+
+    click_link "Create New User"
+
+    fill_in "Name", with: "Fake Joe"
+    fill_in "Email", with: "imnotreal@unreal.org"
+    click_button "Create New User"
+    
+    expect(current_path).to eq(root_path)
+    within(".users") do
+      expect(page).to have_content("Fake Joe")
+    end
+  end
+end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -12,11 +12,29 @@ RSpec.describe "users#new" do
 
     fill_in "Name", with: "Fake Joe"
     fill_in "Email", with: "imnotreal@unreal.org"
-    click_button "Create New User"
-    
-    expect(current_path).to eq(root_path)
+    click_button "Register"
+
+    user = User.where(name: "Fake Joe").first
+    expect(current_path).to eq("/users/#{user.id}")
+    expect(page).to have_content("Fake Joe")
+
+    visit root_path
+
     within(".users") do
       expect(page).to have_content("Fake Joe")
     end
+  end
+
+  it "requires unique email" do
+    User.create!(name: "Duplicate Debby", email: "123@abc.com")
+
+    visit "/register"
+
+    fill_in "Name", with: "Fake Joe"
+    fill_in "Email", with: "123@abc.com"
+    click_button "Register"
+
+    expect(current_path).to eq("/register")
+    expect(page).to have_content("That email has already been registered. Please enter a new email.")
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "user dashboard" do
-  before :all do
+  before :each do
     @user_1 = User.create!(name: "Unreal Ursa", email: "thisaintreal@gotcha.org")
   end
 

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,12 +1,13 @@
 require "rails_helper"
 
-RSpec.describe "users dashboard" do
+RSpec.describe "user dashboard" do
   before :all do
     @user_1 = User.create!(name: "Unreal Ursa", email: "thisaintreal@gotcha.org")
   end
+
   it "displays user name" do
     visit "/users/#{@user_1.id}"
-    save_and_open_page
+
     expect(page).to have_content("Unreal Ursa's Dashboard")
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "users dashboard" do
+  before :all do
+    @user_1 = User.create!(name: "Unreal Ursa", email: "thisaintreal@gotcha.org")
+  end
+  it "displays user name" do
+    visit "/users/#{@user_1.id}"
+    save_and_open_page
+    expect(page).to have_content("Unreal Ursa's Dashboard")
+  end
+end


### PR DESCRIPTION
#Summary of Changes
Completes #8 User Registration Page card:
- `/register` path leads to `users#new` controller with form to create new user
- refactors other controllers+specs to go to `/register` as opposed to `/users/new` when applicable
- new user form requires unique email, flashes error message when not satisfied


#Concerns and/or Areas for Careful Review(tags recommended)
- You'll find the flash message for unique email errors in the create method of the users controller, and notice that currently the only possible alert as of right now is related to unique emails. If we want to add constraints for other things, like names not containing any numbers for example, we'll have to refactor that method to account for different flash messages.
